### PR TITLE
FIX_LVRUBY-66: Set config.assets.compile true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved
   # to config/initializers/assets.rb


### PR DESCRIPTION
## JIRA ticket

_Please provide the URL for the JIRA ticket._

https://ssu-jira.softserveinc.com/browse/LVRUBY-66

## Code reviewers
- [x] @okohuch 
- [x] @AlinaKovtun 

## Summary of issue

Set config.precompile.assets true

## Summary of change

Changes in file production.rb

## Review checklist

- [ ] Rubocop doesn't raise any warnings and offenses
- [ ] New features are covered with new specs
- [ ] All specs pass
