### PR TITLE
LVRUBY-60: Add a share button on News page

### DIFF
--- a/app/assets/javascripts/popup_window.js
+++ b/app/assets/javascripts/popup_window.js
@@ -1,0 +1,20 @@
+document.addEventListener('turbolinks:load', function(){
+  function popupCenter(url, width, height, name) {
+    var left = (screen.width / 2) - (width / 2);
+    var top = (screen.height / 2) - (height / 2);
+    return window.open(url, name, 'menubar=no, toolbar=no, status=no, width=' + width +
+    ', height=' + height + ', toolbar=no, left=' + left + ', top=' + top);
+  }
+
+  $('a.popup').click(function(e) {
+      popupCenter(
+        $(this).attr('href'),
+        $(this).attr('data-width'),
+        $(this).attr('data-height'),
+        'authPopup'
+      );
+      e.stopPropagation();
+      return false;
+    });
+  }
+);

--- a/app/assets/stylesheets/pages/news.scss
+++ b/app/assets/stylesheets/pages/news.scss
@@ -54,3 +54,7 @@ img .portrait {
 .img-comment {
   width: 70px;
 }
+
+.social-icon {
+  font-size: 20px;
+}

--- a/app/views/news/_share_buttons.html.haml
+++ b/app/views/news/_share_buttons.html.haml
@@ -1,0 +1,11 @@
+= link_to fa_icon('facebook-square'),
+"https://www.facebook.com/sharer/sharer.php?u=#{news.title}&quote=#{news.title}",
+class: 'social-icon popup ml-2',
+'data-width': 600,
+'data-height': 400
+
+= link_to fa_icon('twitter-square'),
+"http://twitter.com/share?text=#{news.title}&url=#{news_url(news)}",
+class: 'social-icon popup ml-1',
+'data-width': 600,
+'data-height': 400

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -21,10 +21,9 @@
               %strong.text-dark#name
                 = news.user.first_name
                 = news.user.last_name
-            %h6.m-0.text-dark
+            %h5.m-0.text-dark
               = link_to t('news.links.read_more'), news_path(news)
               = fa_icon 'eye', text: news.views, class: 'ml-4'
-              = fa_icon 'share', text: t('news.links.share'), class: 'ml-4'
               = fa_icon 'tags', text: t('news.links.category'), class: 'ml-4'
           .col-lg-4
             .thumbnail

--- a/app/views/news/show.html.haml
+++ b/app/views/news/show.html.haml
@@ -17,5 +17,8 @@
           %img.img-fluid{ src: 'https://mdbootstrap.com/img/Photos/Slides/img%20(134).jpg' }/
           %h4.text-left.mt-4.mb-2
             = @news.body.html_safe
+          %p.mt-4.text-right
+            = t('news.links.share')
+            = render 'share_buttons', news: @news
           %br
       = render 'related_news'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
       edit: 'Edit'
       delete: 'Delete'
       read_more: 'Read more'
-      share: 'Share'
+      share: 'Share with'
       category: 'Category'
       written_by: 'Written by'
     index:


### PR DESCRIPTION
## JIRA ticket

https://ssu-jira.softserveinc.com/browse/LVRUBY-60

## Code reviewers

- [ ] @okohuch 
- [ ] @nataliakozoriz 

## Summary of issue

Add button in order to share link of current News

## Summary of change

Added two links for sharing News via Twitter and Facebook

## Review checklist

- [ ] Rubocop doesn't raise any warnings and offenses
- [ ] New features are covered with new specs
- [ ] All specs pass
![Screenshot from 2019-05-07 14-17-31](https://user-images.githubusercontent.com/27686672/57295787-eb52e700-70d3-11e9-8c86-d1485aa91943.png)


