### PR TITLE
FIX_LVRUBY-66: Add tinymce assets to News form

### DIFF
--- a/app/views/news/_form.html.haml
+++ b/app/views/news/_form.html.haml
@@ -1,3 +1,4 @@
+= tinymce_assets
 = tinymce
 = form_for @news do |form|
   %p

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true
-
+  config.tinymce.install = :compile
   # `config.assets.precompile` and `config.assets.version` have moved
   # to config/initializers/assets.rb
 


### PR DESCRIPTION
## JIRA ticket

https://ssu-jira.softserveinc.com/browse/LVRUBY-66

## Code reviewers

- [ ] @okohuch 

## Summary of issue

Fix problem with assets in production

## Summary of change

Added tinymce assets to news/_form.html.haml

## Review checklist

- [ ] Rubocop doesn't raise any warnings and offenses
- [ ] New features are covered with new specs
- [ ] All specs pass
